### PR TITLE
lavf/tonemap*: use HLG EOTF from BT 2446 Method B

### DIFF
--- a/debian/patches/0004-add-cuda-tonemap-impl.patch
+++ b/debian/patches/0004-add-cuda-tonemap-impl.patch
@@ -338,7 +338,7 @@ Index: FFmpeg/libavfilter/cuda/colorspace_common.h
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/cuda/colorspace_common.h
-@@ -0,0 +1,349 @@
+@@ -0,0 +1,354 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -480,10 +480,15 @@ Index: FFmpeg/libavfilter/cuda/colorspace_common.h
 +    );
 +}
 +
++#define BT2446B_HLG_LW 291.0f
++#define BT2446B_HLG_GAMMA 1.03f
++
 +// linearizer for HLG/ARIB-B67
 +static __inline__ __device__ float3 eotf_arib_b67(float3 x) {
-+    float peak = ARIB_B67_MAX_LUMINANCE / REFERENCE_WHITE_ALT;
-+    float luma, gamma = 1.2f;
++    float peak = hlg_eotf_bt2446b ? (BT2446B_HLG_LW / REFERENCE_WHITE_ALT)
++                                  : (ARIB_B67_MAX_LUMINANCE / REFERENCE_WHITE_ALT);
++    float luma;
++    float gamma = hlg_eotf_bt2446b ? BT2446B_HLG_GAMMA : 1.2f;
 +    float3 a = make_float3(4.0f, 4.0f, 4.0f) * x * x;
 +    float3 b = make_float3(
 +        __expf((x.x - ARIB_B67_C) * (1.0f / ARIB_B67_A)) + ARIB_B67_B,
@@ -1164,7 +1169,7 @@ Index: FFmpeg/libavfilter/cuda/tonemap.cu
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/cuda/tonemap.cu
-@@ -0,0 +1,663 @@
+@@ -0,0 +1,664 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -1195,6 +1200,7 @@ Index: FFmpeg/libavfilter/cuda/tonemap.cu
 +extern __constant__ const int enable_dither;
 +extern __constant__ const float dither_size;
 +extern __constant__ const float dither_quantization;
++extern __constant__ const unsigned char hlg_eotf_bt2446b;
 +
 +#define clamp(a, b, c) min(max((a), (b)), (c))
 +#define mix(x, y, a) ((x) + ((y) - (x)) * (a))
@@ -1987,7 +1993,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemap_cuda.c
-@@ -0,0 +1,1282 @@
+@@ -0,0 +1,1284 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -2727,6 +2733,8 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +    CONSTANT_C("luma_src", av_q2d(in_coeffs->cr), av_q2d(in_coeffs->cg), av_q2d(in_coeffs->cb));
 +    CONSTANT_C("luma_dst", av_q2d(out_coeffs->cr), av_q2d(out_coeffs->cg), av_q2d(out_coeffs->cb));
 +    CONSTANT_C("ycc2rgb_offset", ycc2rgb_offset[0], ycc2rgb_offset[1], ycc2rgb_offset[2]);
++    CONSTANT_A(".u8 hlg_eotf_bt2446b = %i", 1,
++               in_trc == AVCOL_TRC_ARIB_STD_B67 && out_trc != AVCOL_TRC_SMPTE2084);
 +
 +    ret = CHECK_CU(cu->cuCtxPushCurrent(cuda_ctx));
 +    if (ret < 0)

--- a/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -161,7 +161,7 @@ Index: FFmpeg/libavfilter/opencl/colorspace_common.cl
  
  #if chroma_loc == 1
      #define chroma_sample(a,b,c,d) (((a) + (c)) * 0.5f)
-@@ -33,88 +48,119 @@
+@@ -33,88 +48,128 @@
      #define chroma_sample(a,b,c,d) (((a) + (b) + (c) + (d)) * 0.25f)
  #endif
  
@@ -301,10 +301,19 @@ Index: FFmpeg/libavfilter/opencl/colorspace_common.cl
 +    return x;
 +}
 +
++// BT.2446 Method B parameters for HLG to SDR.
++#define BT2446B_HLG_LW 291.0f
++#define BT2446B_HLG_GAMMA 1.03f
++
 +// linearizer for HLG/ARIB-B67
 +float3 eotf_arib_b67x3(float3 x) {
 +    float peak = ARIB_B67_MAX_LUMINANCE / REFERENCE_WHITE_ALT;
-+    float luma, gamma = 1.2f;
++    float luma;
++    float gamma = 1.2f;
++#ifdef HLG_EOTF_BT2446B
++    peak = BT2446B_HLG_LW / REFERENCE_WHITE_ALT;
++    gamma = BT2446B_HLG_GAMMA;
++#endif
 +    float3 a = 4.0f * x * x;
 +    float3 b = native_exp((x - ARIB_B67_C) * (1.0f / ARIB_B67_A)) + ARIB_B67_B;
 +    x = select(a, b, isgreater(x, (float3)(0.5f))) * (1.0f / 12.0f);
@@ -342,7 +351,7 @@ Index: FFmpeg/libavfilter/opencl/colorspace_common.cl
  #endif
      float r = y * rgb_matrix[0] + u * rgb_matrix[1] + v * rgb_matrix[2];
      float g = y * rgb_matrix[3] + u * rgb_matrix[4] + v * rgb_matrix[5];
-@@ -125,10 +171,7 @@ float3 yuv2rgb(float y, float u, float v
+@@ -125,10 +180,7 @@ float3 yuv2rgb(float y, float u, float v
  float3 yuv2lrgb(float3 yuv) {
      float3 rgb = yuv2rgb(yuv.x, yuv.y, yuv.z);
  #ifdef linearize
@@ -354,7 +363,7 @@ Index: FFmpeg/libavfilter/opencl/colorspace_common.cl
  #else
      return rgb;
  #endif
-@@ -138,42 +181,50 @@ float3 rgb2yuv(float r, float g, float b
+@@ -138,42 +190,50 @@ float3 rgb2yuv(float r, float g, float b
      float y = r*yuv_matrix[0] + g*yuv_matrix[1] + b*yuv_matrix[2];
      float u = r*yuv_matrix[3] + g*yuv_matrix[4] + b*yuv_matrix[5];
      float v = r*yuv_matrix[6] + g*yuv_matrix[7] + b*yuv_matrix[8];
@@ -423,7 +432,7 @@ Index: FFmpeg/libavfilter/opencl/colorspace_common.cl
  }
  
  float3 lrgb2lrgb(float3 c) {
-@@ -188,18 +239,94 @@ float3 lrgb2lrgb(float3 c) {
+@@ -188,18 +248,94 @@ float3 lrgb2lrgb(float3 c) {
  #endif
  }
  
@@ -2559,12 +2568,16 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      av_bprintf(&header, "#define chroma_loc %d\n", (int)ctx->chroma_loc);
  
      if (rgb2rgb_passthrough)
-@@ -200,44 +695,60 @@ static int tonemap_opencl_init(AVFilterC
+@@ -200,44 +695,64 @@ static int tonemap_opencl_init(AVFilterC
      else
          ff_opencl_print_const_matrix_3x3(&header, "rgb2rgb", rgb2rgb);
  
 +    if (ctx->trc_out == AVCOL_TRC_SMPTE2084)
 +        av_bprintf(&header, "#define SKIP_TONEMAP\n");
++
++    if (ctx->trc_in == AVCOL_TRC_ARIB_STD_B67 &&
++        ctx->trc_out != AVCOL_TRC_SMPTE2084)
++        av_bprintf(&header, "#define HLG_EOTF_BT2446B\n");
  
      luma_src = av_csp_luma_coeffs_from_avcsp(ctx->colorspace_in);
      if (!luma_src) {
@@ -2640,7 +2653,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      av_log(avctx, AV_LOG_DEBUG, "Generated OpenCL header:\n%s\n", header.str);
      opencl_sources[0] = header.str;
-@@ -255,50 +766,291 @@ static int tonemap_opencl_init(AVFilterC
+@@ -255,50 +770,291 @@ static int tonemap_opencl_init(AVFilterC
      CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to create OpenCL "
                       "command queue %d.\n", cle);
  
@@ -2954,7 +2967,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      return 0;
  }
  
-@@ -309,13 +1061,50 @@ static int launch_kernel(AVFilterContext
+@@ -309,13 +1065,50 @@ static int launch_kernel(AVFilterContext
      size_t global_work[2];
      size_t local_work[2];
      cl_int cle;
@@ -3011,7 +3024,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      local_work[0]  = 16;
      local_work[1]  = 16;
-@@ -339,12 +1128,10 @@ static int tonemap_opencl_filter_frame(A
+@@ -339,12 +1132,10 @@ static int tonemap_opencl_filter_frame(A
      AVFilterContext    *avctx = inlink->dst;
      AVFilterLink     *outlink = avctx->outputs[0];
      TonemapOpenCLContext *ctx = avctx->priv;
@@ -3025,7 +3038,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      av_log(ctx, AV_LOG_DEBUG, "Filter input: %s, %ux%u (%"PRId64").\n",
             av_get_pix_fmt_name(input->format),
-@@ -352,7 +1139,6 @@ static int tonemap_opencl_filter_frame(A
+@@ -352,7 +1143,6 @@ static int tonemap_opencl_filter_frame(A
  
      if (!input->hw_frames_ctx)
          return AVERROR(EINVAL);
@@ -3033,7 +3046,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      output = ff_get_video_buffer(outlink, outlink->w, outlink->h);
      if (!output) {
-@@ -364,17 +1150,66 @@ static int tonemap_opencl_filter_frame(A
+@@ -364,17 +1154,66 @@ static int tonemap_opencl_filter_frame(A
      if (err < 0)
          goto fail;
  
@@ -3106,7 +3119,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      ctx->trc_in = input->color_trc;
      ctx->trc_out = output->color_trc;
-@@ -386,72 +1221,50 @@ static int tonemap_opencl_filter_frame(A
+@@ -386,72 +1225,50 @@ static int tonemap_opencl_filter_frame(A
      ctx->range_out = output->color_range;
      ctx->chroma_loc = output->chroma_location;
  
@@ -3202,7 +3215,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      av_frame_free(&input);
      av_frame_free(&output);
      return err;
-@@ -459,62 +1272,101 @@ fail:
+@@ -459,62 +1276,101 @@ fail:
  
  static av_cold void tonemap_opencl_uninit(AVFilterContext *avctx)
  {
@@ -3351,7 +3364,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      { NULL }
  };
  
-@@ -540,13 +1392,14 @@ static const AVFilterPad tonemap_opencl_
+@@ -540,13 +1396,14 @@ static const AVFilterPad tonemap_opencl_
  const FFFilter ff_vf_tonemap_opencl = {
      .p.name         = "tonemap_opencl",
      .p.description  = NULL_IF_CONFIG_SMALL("Perform HDR to SDR conversion with tonemapping."),

--- a/debian/patches/0046-add-vf-tonemap-videotoolbox-filter.patch
+++ b/debian/patches/0046-add-vf-tonemap-videotoolbox-filter.patch
@@ -40,7 +40,7 @@ Index: FFmpeg/libavfilter/metal/vf_tonemap_videotoolbox.metal
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/metal/vf_tonemap_videotoolbox.metal
-@@ -0,0 +1,899 @@
+@@ -0,0 +1,907 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -72,6 +72,8 @@ Index: FFmpeg/libavfilter/metal/vf_tonemap_videotoolbox.metal
 +
 +#define REFERENCE_WHITE_ALT 203.0f
 +#define REFERENCE_WHITE_HLG 3.17955f
++#define BT2446B_HLG_LW 291.0f
++#define BT2446B_HLG_GAMMA 1.03f
 +
 +#define ST2084_MAX_LUMINANCE 10000.0f
 +#define ARIB_B67_MAX_LUMINANCE 1000.0f
@@ -126,6 +128,7 @@ Index: FFmpeg/libavfilter/metal/vf_tonemap_videotoolbox.metal
 +constant short delinearize_type [[function_constant(35)]];
 +constant bool map_in_src_space [[function_constant(36)]];
 +constant bool is_tone_mode_itp [[function_constant(37)]];
++constant bool hlg_eotf_bt2446b [[function_constant(38)]];
 +
 +enum AVChromaLocation {
 +    AVCHROMA_LOC_UNSPECIFIED,
@@ -221,7 +224,12 @@ Index: FFmpeg/libavfilter/metal/vf_tonemap_videotoolbox.metal
 +// linearizer for HLG/ARIB-B67
 +float3 eotf_arib_b67x3(float3 x) {
 +    float peak = ARIB_B67_MAX_LUMINANCE / REFERENCE_WHITE_ALT;
-+    float luma, gamma = 1.2f;
++    float luma;
++    float gamma = 1.2f;
++    if (hlg_eotf_bt2446b) {
++        peak = BT2446B_HLG_LW / REFERENCE_WHITE_ALT;
++        gamma = BT2446B_HLG_GAMMA;
++    }
 +    float3 a = 4.0f * x * x;
 +    float3 b = exp((x - ARIB_B67_C) * (1.0f / ARIB_B67_A)) + ARIB_B67_B;
 +    x = select(a, b, x > float3(0.5f)) * (1.0f / 12.0f);
@@ -944,7 +952,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
-@@ -0,0 +1,1226 @@
+@@ -0,0 +1,1230 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -1303,6 +1311,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +    bool is_full_range_out;
 +    int chroma_loc;
 +    bool skip_tonemap;
++    bool hlg_eotf_bt2446b;
 +    bool dovi_reshape;
 +    bool map_in_src_space;
 +
@@ -1446,6 +1455,8 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +    is_full_range_out = ctx->range_out == AVCOL_RANGE_JPEG;
 +    chroma_loc = (int)ctx->chroma_loc;
 +    skip_tonemap = ctx->trc_out == AVCOL_TRC_SMPTE2084;
++    hlg_eotf_bt2446b = ctx->trc_in == AVCOL_TRC_ARIB_STD_B67 &&
++                       ctx->trc_out != AVCOL_TRC_SMPTE2084;
 +    dovi_reshape = !!ctx->dovi;
 +    map_in_src_space = !is_tone_mode_rgb && !is_tone_mode_max;
 +
@@ -1517,6 +1528,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +    [constant_values setConstantValue:&mtl_luma_dst type:MTLDataTypeFloat3 withName:@"luma_dst"];
 +
 +    [constant_values setConstantValue:&skip_tonemap type:MTLDataTypeBool withName:@"skip_tonemap"];
++    [constant_values setConstantValue:&hlg_eotf_bt2446b type:MTLDataTypeBool withName:@"hlg_eotf_bt2446b"];
 +    [constant_values setConstantValue:&dovi_reshape type:MTLDataTypeBool withName:@"dovi_reshape"];
 +    if (dovi_reshape) {
 +        for (i = 0; i < 3; i++) {

--- a/debian/patches/0053-add-simd-optimized-tonemapx-filter.patch
+++ b/debian/patches/0053-add-simd-optimized-tonemapx-filter.patch
@@ -2637,7 +2637,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemapx.c
-@@ -0,0 +1,1973 @@
+@@ -0,0 +1,2000 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -2701,6 +2701,8 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +#define CLAMP(a, b, c) (FFMIN(FFMAX((a), (b)), (c)))
 +
 +#define REF_WHITE_SCALE (REFERENCE_WHITE / REFERENCE_WHITE_ALT)
++#define BT2446B_HLG_LW 291.0f
++#define BT2446B_HLG_GAMMA 1.03f
 +
 +enum TonemapAlgorithm {
 +    TONEMAP_NONE,
@@ -3182,26 +3184,53 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +        return x;
 +}
 +
++static int hlg_eotf_bt2446b_enabled(enum AVColorTransferCharacteristic trc_src,
++                                    enum AVColorTransferCharacteristic trc_dst)
++{
++    return trc_src == AVCOL_TRC_ARIB_STD_B67 &&
++           trc_dst != AVCOL_TRC_SMPTE2084;
++}
++
++static float inverse_oetf_arib_b67(float x)
++{
++    float a = 4.0f * x * x;
++    float b = expf((x - ARIB_B67_C) * (1.0f / ARIB_B67_A)) + ARIB_B67_B;
++
++    return (x > 0.5f ? b : a) * (1.0f / 12.0f);
++}
++
++static float linearize_hlg_eotf_bt2446b(float x)
++{
++    x = inverse_oetf_arib_b67(x);
++    return FFMAX((BT2446B_HLG_LW / REFERENCE_WHITE_ALT) *
++                 powf(FFMAX(x, 0.0f), BT2446B_HLG_GAMMA), 0.0f);
++}
++
 +static int compute_trc_luts(TonemapxContext *s, enum AVColorTransferCharacteristic trc_src,
 +                            enum AVColorTransferCharacteristic trc_dst)
 +{
 +    int i;
++    int hlg_eotf_bt2446b = hlg_eotf_bt2446b_enabled(trc_src, trc_dst);
 +
 +    if (!s->lin_lut && !(s->lin_lut = av_calloc(32768, sizeof(float))))
 +        return AVERROR(ENOMEM);
 +    if (!s->delin_lut && !(s->delin_lut = av_calloc(32768, sizeof(uint16_t))))
 +        return AVERROR(ENOMEM);
-+
 +    for (i = 0; i < 32768; i++) {
 +        float v = (float)i / JPEG_SCALE;
-+        s->lin_lut[i] = FFMAX(linearize(v, trc_src), 0);
++        if (hlg_eotf_bt2446b) {
++            s->lin_lut[i] = linearize_hlg_eotf_bt2446b(v);
++        } else {
++            s->lin_lut[i] = FFMAX(linearize(v, trc_src), 0);
++        }
 +        s->delin_lut[i] = av_clip_int16((int)rintf(delinearize(v, trc_dst) * JPEG_SCALE));
 +    }
 +
 +    return 0;
 +}
 +
-+static int compute_tonemap_lut(TonemapxContext *s, enum AVColorTransferCharacteristic trc_src)
++static int compute_tonemap_lut(TonemapxContext *s, enum AVColorTransferCharacteristic trc_src,
++                               enum AVColorTransferCharacteristic trc_dst)
 +{
 +    int i;
 +    double peak = s->lut_peak;
@@ -3211,7 +3240,9 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +
 +    for (i = 0; i < 32768; i++) {
 +        float v = (float)i / JPEG_SCALE;
-+        float sig = linearize(v, trc_src);
++        float sig = hlg_eotf_bt2446b_enabled(trc_src, trc_dst)
++                    ? linearize_hlg_eotf_bt2446b(v)
++                    : linearize(v, trc_src);
 +        float mapped = mapsig(s->tonemap, sig, peak, s->param);
 +        s->tonemap_lut[i] = (sig > 0.0f && mapped > 0.0f) ? mapped / sig : 0.0f;
 +    }
@@ -3347,8 +3378,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +                                 double (*rgb2rgb)[3][3],
 +                                 int rgb2rgb_passthrough)
 +{
-+    int16_t sig;
-+    float mapval, r_lin, g_lin, b_lin;
++    float r_lin, g_lin, b_lin;
 +
 +    r_in = av_clip_uintp2(r_in, 15);
 +    g_in = av_clip_uintp2(g_in, 15);
@@ -3358,13 +3388,6 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +    *r_out = r_in;
 +    *g_out = g_in;
 +    *b_out = b_in;
-+
-+    /* pick the brightest component, reducing the value range as necessary
-+     * to keep the entire signal in range and preventing discoloration due to
-+     * out-of-bounds clipping */
-+    sig = FFMAX3(r_in, g_in, b_in);
-+
-+    mapval = tonemap_lut[sig];
 +
 +    r_lin = lin_lut[r_in];
 +    g_lin = lin_lut[g_in];
@@ -3386,6 +3409,10 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +        b_lin = MIX(b_lin, luma, overbright);
 +    }
 +
++    /* pick the brightest component, reducing the value range as necessary
++     * to keep the entire signal in range and preventing discoloration due to
++     * out-of-bounds clipping */
++    float mapval = tonemap_lut[FFMAX3(r_in, g_in, b_in)];
 +    r_lin *= mapval;
 +    g_lin *= mapval;
 +    b_lin *= mapval;
@@ -4233,7 +4260,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +
 +    if (!s->tonemap_lut || s->lut_peak != s->src_peak) {
 +        s->lut_peak = s->src_peak;
-+        if ((ret = compute_tonemap_lut(s, in->color_trc)) < 0)
++        if ((ret = compute_tonemap_lut(s, in->color_trc, out->color_trc)) < 0)
 +            goto fail;
 +    }
 +


### PR DESCRIPTION
We previously used the spec convention of Lw=1000 and gamma = 1.2 for HLG EOTF to linear space, but that mapping works terribly with common tonemap operators as that would map too many of the area above diffusion white and make the result overly bright.

In ITU report BT.2446-1 page 15, it recommends to use Lw=291 with a gamma of 1.03 so that the mapped HLG diffusion white is at around 90% of SDR peak of BT.1886, or around 78nit. This compress most of the signal into near SDR range before we apply any tonemap operators, and it shows promising results.

This approach also requires least code change as we only need to modify EOTF of HLG for each implementations, and it has no performance impact.

Currently only apply this to non PQ outputs, so that if we are doing HDR to HDR tone mapping in the future we still use the standard convention Lw=1000.

With this approach BT.2390 works much better:

<img width="852" height="1452" alt="image" src="https://github.com/user-attachments/assets/f7037d7b-31ad-4e45-92df-3bf6d4dd2c2e" />
<img width="1280" height="765" alt="Screenshot 2026-05-21 at 21 35 39" src="https://github.com/user-attachments/assets/e1a6b5de-b70e-4422-af01-60b6f2c5558f" />
<img width="1280" height="779" alt="Screenshot 2026-05-21 at 21 37 29" src="https://github.com/user-attachments/assets/a34accdf-bf3c-4be2-9684-d8c0f7e21889" />

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Related:
https://github.com/jellyfin/jellyfin-ffmpeg/pull/706